### PR TITLE
Log requests

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -27,6 +27,7 @@ module.exports = function (settingsDir) {
     properties_default.server.sockets = process.env.SOCKETS || properties_default.server.sockets
     properties_default.server.sockets_redis = process.env.SOCKETS_REDIS || properties_default.server.sockets_redis
     properties_default.server.sockets_redis = (properties_default.server.sockets_redis === 'true')
+    properties_default.server.log_requests = process.env.LOG_REQUESTS || (properties_default.server.log_requests === 'true')
   }
   if (properties_default.ssl) {
     properties_default.ssl.key = process.env.KEY_FILE || properties_default.ssl.key

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,6 +18,7 @@ var cors = require('cors')
 var consolidate = require('consolidate')
 var proxiedHttp = require('findhit-proxywrap')
 var redis = require('redis')
+var morgan = require('morgan')
 
 module.exports = function (properties) {
   // Server and Middlewares properties
@@ -79,6 +80,7 @@ module.exports = function (properties) {
   requestid && app.use(requestid)
   // Adds optional express logging to winston logger
   expressWinston.requestWhitelist.push('body')
+  app.use(morgan('short', {immediate: true}))
   logger && app.use(expressWinston.logger({
     winstonInstance: logger,
     meta: true,

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,6 +33,7 @@ module.exports = function (properties) {
   var compression_level = properties.server.compression == null ? 6 : properties.server.compression
   var proxy = properties.server.proxy
   var proxy_strict = properties.server.proxy_strict
+  var log_requests = properties.server.log_requests
   var key_file = properties.ssl && properties.ssl.key
   var crt_file = properties.ssl && properties.ssl.crt
   var redis_host = properties.redis && properties.redis.host
@@ -80,7 +81,7 @@ module.exports = function (properties) {
   requestid && app.use(requestid)
   // Adds optional express logging to winston logger
   expressWinston.requestWhitelist.push('body')
-  app.use(morgan('short', {immediate: true}))
+  log_requests && app.use(morgan('short', {immediate: true}))
   logger && app.use(expressWinston.logger({
     winstonInstance: logger,
     meta: true,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mongoose": "~4.4.3",
     "mongoose-merge-plugin": "0.0.5",
     "mongoose-time": "^0.1.0",
+    "morgan": "^1.7.0",
     "on-finished": "^2.3.0",
     "passport": "^0.3.0",
     "passport-http": "^0.3.0",


### PR DESCRIPTION
Allowing to log requests _without_ waiting for them to be responded.
This is useful for cases such as debugging when the server hangs or crashes and never responds the request.
