### PR TITLE
log.level for minimal log level to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ var logentries_api_key = 'fdsfdf23fewfew'
 
 var log_settings = {
   env: env,
-  logentries_api_ley: logentries_api_key,
+  logentries_api_key: logentries_api_key,
   log_dir: './log'
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var winston = require('winston')
-// var mail = require('winston-mail')
 var fs = require('fs')
 var logentries = require('le_node')
 var assert = require('assert')
@@ -12,145 +11,41 @@ function custom_time_stamp1 () {
   return date.getUTCDate() + '/' + month + '/' + date.getFullYear() + '-' + date.getUTCHours() + ':' + date.getUTCMinutes() + ':' + date.getUTCSeconds()
 }
 
-// var custom_time_stamp2 = function () {
-//   var date = new Date()
-//   var month = date.getUTCMonth() + 1
-//   return date.getUTCDate() + '/' + month + '/' + date.getFullYear() + '-' + date.getUTCHours() + ':' + date.getUTCMinutes() + ':' + date.getUTCSeconds() + ':' + date.getUTCMilliseconds()
-// }
-
-function development_transports (myToken) {
-  var temp = [
-    new (winston.transports.Console)({
-      level: 'silly',
-      colorize: true,
-      silent: false,
-      timestamp: custom_time_stamp1
-    })
-    // new (winston.transports.DailyRotateFile)({
-    //   level: 'silly',
-    //   filename: __dirname + '/../log/log.txt',
-    //   maxsize: 500000,
-    //   prettyPrint: true,
-    //   silent: false,
-    //   timestamp: custom_time_stamp2
-    // })
-  ]
-  return temp
-}
-
-function qa_transports (myToken) {
-  var temp = [
-    new (winston.transports.Console)({
-      level: 'silly',
-      colorize: true,
-      silent: false,
-      timestamp: custom_time_stamp1
-    })
-    // new (winston.transports.DailyRotateFile)({
-    //   level: 'silly',
-    //   filename: __dirname + '/../log/log.txt',
-    //   maxsize: 500000,
-    //   prettyPrint: true,
-    //   silent: false,
-    //   timestamp: custom_time_stamp2
-    // }),
-    // new (mail.Mail)({
-    //   to: 'thehobbit85@gmail.com',
-    //   level: 'warn',
-    //   silent: true,
-    //   token: myToken
-    //   // handleExceptions: true
-    //   // from: The address you want to send from. (default: winston@[server-host-name])
-    //   // host: SMTP server hostname (default: localhost)
-    //   // port: SMTP port (default: 587 or 25)
-    //   // username: User for server auth
-    //   // password: Password for server auth
-    //   // subject Subject for email (default: winston: {{level}} {{msg}})
-    //   // ssl: Use SSL (boolean or object { key, ca, cert })
-    // })
-  ]
-  return temp
-}
-
-function production_transports (myToken) {
-  var temp = [
-    new (winston.transports.Console)({
-      level: 'info',
-      colorize: true,
-      silent: false,
-      timestamp: custom_time_stamp1
-    })
-    // new (winston.transports.Console)({
-    //   level: 'info',
-    //   colorize: true,
-    //   silent: false,
-    //   timestamp: custom_time_stamp1
-    // }),
-    // new (winston.transports.DailyRotateFile)({
-    //   level: 'info',
-    //   filename: __dirname + '/../log/log.txt',
-    //   maxsize: 500000,
-    //   prettyPrint: true,
-    //   silent: false,
-    //   timestamp: custom_time_stamp2
-    // }),
-    // new (mail.Mail)({
-    //   to: 'thehobbit85@gmail.com',
-    //   level: 'warn',
-    //   silent: true
-    //   // handleExceptions: true
-    //   // from: The address you want to send from. (default: winston@[server-host-name])
-    //   // host: SMTP server hostname (default: localhost)
-    //   // port: SMTP port (default: 587 or 25)
-    //   // username: User for server auth
-    //   // password: Password for server auth
-    //   // subject Subject for email (default: winston: {{level}} {{msg}})
-    //   // ssl: Use SSL (boolean or object { key, ca, cert })
-    // })
-  ]
-  return temp
-}
-
-function defaultTransports () {
-  var temp = [
-    new (winston.transports.Console)({
-      level: 'silly',
-      colorize: true,
-      silent: false,
-      timestamp: custom_time_stamp1
-    })
-  ]
-  return temp
-}
+var defaultTransports = [
+  new (winston.transports.Console)({
+    colorize: true,
+    silent: false,
+    timestamp: custom_time_stamp1
+  })
+]
 
 module.exports = function (settings) {
   var env = settings.env || process.env.NODE_ENV
-  var logentries_api_ley = settings.logentries_api_ley
-  var transports = settings.transports
+  var logentries_api_key = settings.logentries_api_key
   var cli = settings.cli
   var logger
   var dir = (settings.log_dir)
   if (!fs.existsSync(dir)) fs.mkdirSync(dir)
-  if (transports) {
-    logger = new (winston.Logger)(transports)
-  } else {
+  var transports = settings.transports || defaultTransports
+  var level = settings.level
+  if (!level) {
     switch (env) {
       case 'development':
-        logger = new (winston.Logger)({transports: development_transports(myToken)})
+        level = 'silly'
         break
       case 'QA':
-        logger = new (winston.Logger)({transports: qa_transports(myToken)})
+        level = 'debug'
         break
       case 'production':
-        logger = new (winston.Logger)({transports: production_transports(myToken)})
+        level = 'info'
         break
       default:
-        logger = new (winston.Logger)({transports: defaultTransports()})
+        level = 'silly'
         break
     }
   }
-  assert(logentries)
-  var myToken = process.env.LOG_API_KEY || logentries_api_ley
+  logger = new (winston.Logger)({level: level, transports: transports})
+  var myToken = process.env.LOG_API_KEY || logentries_api_key
   if (myToken) {
     logger.add(winston.transports.Logentries, {
       token: myToken,
@@ -163,27 +58,7 @@ module.exports = function (settings) {
   logger.addFilter(function (msg, meta, level) {
     return '(' + process.pid + ') - ' + msg
   })
-  // logger.exitOnError = false
 
   if (cli) logger.cli()
-  //  console.log(logger)
   return logger
 }
-
-// levels = {
-//   silly: 0,
-//   debug: 1,
-//   verbose: 2,
-//   info: 3,
-//   warn: 4,
-//   error: 5
-// }
-
-// colors = {
-//   silly: 'magenta',
-//   verbose: 'cyan',
-//   debug: 'blue',
-//   info: 'green',
-//   warn: 'yellow',
-//   error: 'red'
-// }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -17,8 +17,9 @@ module.exports = function (settingsDir) {
   if (properties_default.JWT) {
     properties_default.JWT.jwtTokenSecret = process.env.JWTTOKENSECRET || properties_default.JWT && properties_default.JWT.jwtTokenSecret
   }
-  if (properties_default.logentries) {
-    properties_default.logentries.api_key = process.env.LOG_API_KEY || properties_default.logentries && properties_default.logentries.api_key
+  if (properties_default.log) {
+    properties_default.log.logentries_api_key = process.env.LOG_API_KEY || properties_default.log.logentries_api_key
+    properties_default.log.level = process.env.LOG_LEVEL || properties_default.log.logentries_api_key
   }
   if (properties_default.server) {
     properties_default.server.https_port = process.env.SSL_PORT || properties_default.server.https_port

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -19,7 +19,7 @@ module.exports = function (settingsDir) {
   }
   if (properties_default.log) {
     properties_default.log.logentries_api_key = process.env.LOG_API_KEY || properties_default.log.logentries_api_key
-    properties_default.log.level = process.env.LOG_LEVEL || properties_default.log.logentries_api_key
+    properties_default.log.level = process.env.LOG_LEVEL || properties_default.log.level
   }
   if (properties_default.server) {
     properties_default.server.https_port = process.env.SSL_PORT || properties_default.server.https_port


### PR DESCRIPTION
Allow `level` as an optional parameter for logger - minimal log level to output (options are conventional 'silly', 'debug', 'info', 'verbose', 'warn' and 'error').
Also possible to use environment variable `LOG_LEVEL`.

This is a candidate for incrementing minor version due to these breaking change reasons:
1 - Instead of `logentries` entry in .conf file, we have `log` and corresponding `logentries_api_key` as child property.
2 - typo fix in logger: accepts `logentries_api_key` instead of `logentries_api_ley`.
3 - transports parameter change in logger: previously needed to send `{transports: transportsObject}`, now only needed to use `transportsObject` itself.