### PR TITLE
Database URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ var settings = {
   host: 'host.mongodb.com',
   port: 27000,
   name: 'testDB',
+
+  // with URI - if provided, all previous connection settings are ignored
+  uri: 'mongodb://user:password@host.mongodb.com:27000/testDB',
+
+  // mongoose models directory
   dir: './db'
 }
 db.init(settings, mongoose, function (err, mongoose) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,6 +4,7 @@ var mongoose
 var timestamps = require('mongoose-time')
 var fs = require('fs')
 var merge = require('mongoose-merge-plugin')
+var mongoUriBuilder = require('mongo-uri-node')
 
 function load_models (model_path) {
   fs.readdirSync(model_path).forEach(function (file) {
@@ -16,13 +17,14 @@ function load_models (model_path) {
 
 module.exports = {
   init: function (settings, mongooseInstance, cb) {
+    var username = settings.user,
+    var password = settings.pass,
+    var host = settings.host,
+    var port = settings.port,
+    var database = settings.name
+    var uri = settings.uri || mongoUriBuilder({username: username, password: password, hosts: [{host: host, port: port}], database: database})
     mongoose = mongooseInstance || require('mongoose')
     mongoose.plugin(merge)
-    var mongoCollectionName = settings.name
-    var mongoHost = settings.host
-    var mongoPort = settings.port
-    var mongoUser = settings.user
-    var mongoPass = settings.pass
     var DefaultSchema = mongoose.Schema
 
     mongoose.DefaultSchema = DefaultSchema
@@ -35,7 +37,6 @@ module.exports = {
       if (cb) return cb('Can\'t connect to Database')
       throw new Error('Can\'t connect to Database')
     }
-    var dbURI = mongoHost + ':' + mongoPort + '/' + mongoCollectionName
     var options = {
       server: {
         socketOptions: {
@@ -48,13 +49,11 @@ module.exports = {
           keepAlive: 1,
           connectTimeoutMS: 30000
         }
-      },
-      user: mongoUser,
-      pass: mongoPass
+      }
     }
     // CONNECTION EVENTS
     mongoose.connection.on('connected', function () {
-      console.log('Database connected to: ' + dbURI)
+      console.log('Database connected to: ' + uri)
     })
     mongoose.connection.on('error', function (err) {
       console.log('Mongoose default connection error: ' + err)
@@ -63,7 +62,7 @@ module.exports = {
       console.log('Database disconnected')
     })
     mongoose.connection.once('open', function () {
-      console.log('Database is open: ' + dbURI)
+      console.log('Database is open: ' + uri)
     })
     // If the Node process ends, close the Mongoose connection
     process.on('SIGINT', function () {
@@ -74,7 +73,7 @@ module.exports = {
     })
     settings.dir && load_models(settings.dir)
     console.log('Connecting to Database...')
-    mongoose.connect(dbURI, options, function () {
+    mongoose.connect(uri, options, function () {
       if (cb) cb(null, mongoose)
     })
   },

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,7 +4,7 @@ var mongoose
 var timestamps = require('mongoose-time')
 var fs = require('fs')
 var merge = require('mongoose-merge-plugin')
-var mongoUriBuilder = require('mongo-uri-node')
+var mongoUri = require('mongodb-uri')
 
 function load_models (model_path) {
   fs.readdirSync(model_path).forEach(function (file) {
@@ -17,12 +17,12 @@ function load_models (model_path) {
 
 module.exports = {
   init: function (settings, mongooseInstance, cb) {
-    var username = settings.user,
-    var password = settings.pass,
-    var host = settings.host,
-    var port = settings.port,
+    var username = settings.user
+    var password = settings.pass
+    var host = settings.host
+    var port = settings.port
     var database = settings.name
-    var uri = settings.uri || mongoUriBuilder({username: username, password: password, hosts: [{host: host, port: port}], database: database})
+    var uri = settings.uri || mongoUri.format({username: username, password: password, hosts: [{host: host, port: port}], database: database})
     mongoose = mongooseInstance || require('mongoose')
     mongoose.plugin(merge)
     var DefaultSchema = mongoose.Schema

--- a/lib/db.js
+++ b/lib/db.js
@@ -22,7 +22,7 @@ module.exports = {
     var host = settings.host
     var port = settings.port
     var database = settings.name
-    var uri = settings.uri || mongoUri.format({username: username, password: password, hosts: [{host: host, port: port}], database: database})
+    var uri = settings.uri
     mongoose = mongooseInstance || require('mongoose')
     mongoose.plugin(merge)
     var DefaultSchema = mongoose.Schema
@@ -33,10 +33,11 @@ module.exports = {
       newSchema.plugin(timestamps())
       return newSchema
     }
-    if (!mongoCollectionName || !mongoHost || !mongoPort) {
+    if (!uri && (!database || !host || !port)) {
       if (cb) return cb('Can\'t connect to Database')
       throw new Error('Can\'t connect to Database')
     }
+    uri = uri || mongoUri.formatMongoose({username: username, password: password, hosts: [{host: host, port: port}], database: database})
     var options = {
       server: {
         socketOptions: {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -46,6 +46,7 @@ module.exports = function (settingsDir) {
     properties_default.db.user = process.env.DBUSER || properties_default.db.user
     properties_default.db.pass = process.env.DBPASS || properties_default.db.pass
     properties_default.db.dir = process.env.DBDIR || properties_default.db.dir
+    properties_default.db.uri = process.env.DBURI || properties_default.db.uri
   }
   if (properties_default.redis) {
     properties_default.redis.host = process.env.REDISHOST || properties_default.redis.host

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lodash": "^3.10.1",
     "merge": "^1.2.0",
     "moment": "^2.10.6",
+    "mongodb-uri": "0.9.7",
     "mongoose": "~4.4.3",
     "mongoose-merge-plugin": "0.0.5",
     "mongoose-time": "^0.1.0",


### PR DESCRIPTION
One can input MongoDB URI string with `DBURI` environment variable, or in respective properties.conf file, such as in the example:
```
[db]
uri=mongodb://localhost:27017/my-db
```
In case provided, it overrides all other DB connection settings (user, password, host, port, database name).